### PR TITLE
Update README.md and Make wsURI localhost:8887 by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ But in short, add the GraphWalker Websocket maven dependency to your test projec
 <dependency>
    <groupId>org.graphwalker</groupId>
    <artifactId>graphwalker-websocket</artifactId>
-   <version>4.1.0</version>
+   <version>4.3.2</version>
 </dependency>
 ```
 

--- a/index.html
+++ b/index.html
@@ -418,7 +418,9 @@ THE SOFTWARE.
         var wsUri = '';
         $(document).ready(function () {
             console.log("ready!");
-            wsUri = 'ws://' + getUrlVars()["wsURI"];
+            const urlVars = getUrlVars();
+            const isEmpty = Object.keys(urlVars).length === 0;
+            wsUri = `ws://${isEmpty ? 'localhost:8887' : urlVars["wsURI"]}`;
             connectWebSocket();
         });
     </script>


### PR DESCRIPTION
Latest version of GraphWalker does not work with GraphPlayer. When all of the dependencies set to latest version everything works fine.